### PR TITLE
Corrigir as informações do projeto no package.json e package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "jubileutasklistapi",
+  "name": "nexo-task-api",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "jubileutasklistapi",
+      "name": "nexo-task-api",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "jubileutasklistapi",
+  "name": "nexo-task-api",
   "version": "1.0.0",
   "description": "",
-  "homepage": "https://github.com/Chyod-s/JubileuTaskListAPI#readme",
+  "homepage": "https://github.com/Ton-Chyod-s/nexo-task-api#readme",
   "bugs": {
-    "url": "https://github.com/Chyod-s/JubileuTaskListAPI/issues"
+    "url": "https://github.com/Ton-Chyod-s/nexo-task-api/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Chyod-s/JubileuTaskListAPI.git"
+    "url": "git+https://github.com/Ton-Chyod-s/nexo-task-api.git"
   },
   "license": "ISC",
   "author": "",


### PR DESCRIPTION
Atualize o nome do projeto e as URLs relacionadas para refletir o novo nome do repositório.